### PR TITLE
Forward published events to correct endpoints

### DIFF
--- a/commonCommands.txt
+++ b/commonCommands.txt
@@ -1,4 +1,4 @@
-curl -v -H "Content-Type: application/json" -X POST -d '{"systemName": "haritest1", "applicationEndpoint": "stupid"}' https://lit-sea-20426.herokuapp.com/register/system
+curl -v -H "Content-Type: application/json" -X POST -d '{"systemName": "haritest1", "applicationEndpoint": "https://still-taiga-23440.herokuapp.com"}' https://lit-sea-20426.herokuapp.com/register/system
 
 curl -v -H "Content-Type: application/json" -X POST -d '{"topicName": "testtopic1", "description": "something stupid", "owner": "haritest1", "structure": "{\"struct1\": \"value1\"}"}' https://lit-sea-20426.herokuapp.com/register/topic
 


### PR DESCRIPTION
This is basically pushes events as a POST to appropriate URLs. Note that the POST occurs in a go routine (a separate thread) that times out in a minute. This is to reduce any slow down, we remove the concurrency later if we so desire.