### PR TITLE
Allow event data to be object instead of string

### DIFF
--- a/commonCommands.txt
+++ b/commonCommands.txt
@@ -3,3 +3,5 @@ curl -v -H "Content-Type: application/json" -X POST -d '{"systemName": "haritest
 curl -v -H "Content-Type: application/json" -X POST -d '{"topicName": "testtopic1", "description": "something stupid", "owner": "haritest1", "structure": "{\"struct1\": \"value1\"}"}' https://lit-sea-20426.herokuapp.com/register/topic
 
 curl -v -H "Content-Type: application/json" -X POST -d '{"topicName": "testtopic1", "data": "{\"struct1\": \"value1\"}"}' https://lit-sea-20426.herokuapp.com/publish
+
+curl -v -H "Content-Type: application/json" -X POST -d @orderData.txt https://lit-sea-20426.herokuapp.com/register/topic

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ type Topic struct {
 
 type Event struct {
 	Topic string `json:"topicName"`
-	Data string `json:"data"`
+	Data interface{} `json:"data"`
 }
 
 func index(w http.ResponseWriter, r *http.Request) {
@@ -206,11 +206,18 @@ func publish(w http.ResponseWriter, r *http.Request) {
 	var newEvent Event
 	err := decoder.Decode(&newEvent)
 	if err != nil {
-		log.Printf("Error decoding register topic POST: %v\n", err)
+		log.Printf("Error decoding published topic event POST: %v\n", err)
     	http.Error(w, "Error decoding POST body", http.StatusBadRequest)
 		return
 	}
 	log.Printf("%+v\n", newEvent)
+
+	_, err = json.Marshal(&(newEvent.Data))
+	if (err != nil) {
+		log.Printf("Invalid JSON data in published event: %v\n", err)
+    	http.Error(w, "Invalid JSON in data field", http.StatusBadRequest)
+		return
+	}
 
 	subscriptionsColumn, err := db.Query(fmt.Sprintf("SELECT subscribers FROM topics WHERE name = '%v'", newEvent.Topic))
 	if err != nil {

--- a/orderData.txt
+++ b/orderData.txt
@@ -1,0 +1,84 @@
+{
+    "topicName": "Order Data",
+    "description": "Sales and Marketing Outgoing Order Data",
+    "owner": "sales",
+    "structure": "{
+        \"billing_address\":{
+            \"address1\":\"1111 MYStreet Road\",
+            \"address2\":\"\",
+            \"city\":\"Mississauga\",
+            \"company\":\"None\",
+            \"country\":\"Canada\",
+            \"first_name\":\"Michael\",
+            \"last_name\":\"Kainth\",
+            \"name\":\"Michael Kainth\",
+            \"phone\":\"+1 647-555-0672\",
+            \"province\":\"Ontario\",
+            \"zip\":\"L5M1X1\"
+        },
+        \"card_details\":{  
+            \"credit_card_company\":\"Visa\",
+            \"credit_card_number\":\"1\",
+            \"cvv_result\":\"M\"
+        },
+        \"currency\":\"CAD\",
+        \"customer\":{  
+            \"email\":\"None\",
+            \"first_name\":\"Michael\",
+            \"id\":521180446771,
+            \"ip_address\":\"101.161.231.178\",
+            \"last_name\":\"Kainth\",
+            \"phone\":\"+16475550672\"
+        },
+        \"items\":[  
+            {  
+                \"model\":\"Moto 450\",
+                \"price\":\"24597.00\",
+                \"quantity\":1,
+                \"product_id\":\"019\",
+                \"year\":\"2015\"
+            },
+            {  
+                \"model\":\"Enduro 250\",
+                \"price\":\"13597.00\",
+                \"quantity\":1,
+                \"product_id\":\"002\",
+                \"year\":\"2013\"
+            }
+        ],
+        \"items_subtotal\":\"38194.00\",
+        \"orderID\":1003,
+        \"shipping_address\":{  
+            \"address1\":\"1111 MYStreet Road\",
+            \"address2\":\"\",
+            \"city\":\"Mississauga\",
+            \"company\":\"None\",
+            \"country\":\"Canada\",
+            \"country_code\":\"CA\",
+            \"first_name\":\"Michael\",
+            \"last_name\":\"Kainth\",
+            \"latitude\":41.1782405,
+            \"longitude\":-54.3908803,
+            \"name\":\"Michael Kainth\",
+            \"phone\":\"+1 647-555-0672\",
+            \"province\":\"Ontario\",
+            \"province_code\":\"ON\",
+            \"zip\":\"L5M1X1\"
+        },
+        \"shipping_price\":\"500.00\",
+        \"status_url\":\"https://shop.michaelkainth.com/435945523/orders/338cfe8c18a3943c8f75a2d94f05c0f2/authenticate?key=5cac2a654f1dc070eff2f76cea6c9b11\",
+        \"subtotal\":\"38194.00\",
+        \"taxes\":[  
+            {  
+                \"name\":\"HST\",
+                \"price\":\"4965.22\",
+                \"rate\":0.13
+            }
+        ],
+        \"timestamp\":\"2018-03-25T01:07:23-04:00\",
+        \"total_discounts\":\"0.00\",
+        \"total_price\":\"43659.22\",
+        \"total_tax\":\"4965.22\",
+        \"total_weight\":345000
+    }"
+}


### PR DESCRIPTION
Added Michael's test Order Data. The major change is changing the data field from a string to an interface{} and just checking if it is a valid JSON object.